### PR TITLE
Reorganize script.js map logic and UI code

### DIFF
--- a/script.js
+++ b/script.js
@@ -517,13 +517,8 @@ window.addEventListener('DOMContentLoaded', () => {
   // COG protocol   
   maplibregl.addProtocol('cog', MaplibreCOGProtocol.cogProtocol);
   
-  map.on('zoom', () => {
-  document.getElementById('zoom-value').textContent = map.getZoom().toFixed(2);
-});
-
   map.on('load', async () => {
     // Build UI - handles all defaults (country, year, layers)
-    document.getElementById('zoom-value').textContent = map.getZoom().toFixed(2);
     buildUI();
   });
 


### PR DESCRIPTION
Reorganize `script.js` back to map.on('load') without zoom event handler and initialize #zoom-value on load to prevent error message "Uncaught (in promise) TypeError: Cannot set properties of null (setting 'textContent')".  